### PR TITLE
fix state node name

### DIFF
--- a/tello.html
+++ b/tello.html
@@ -188,7 +188,7 @@
         outputs:1,
         icon: "font-awesome/fa-search",
         label: function() {
-            return this.name||"state";
+            return this.name||this.command;
         }
     });
 


### PR DESCRIPTION
# Updated
- Fixed state node name
- If `this.name` is blank, display name is referenced `this.command`